### PR TITLE
Make minimum gap between distributions depend on data extrema, rather than just 1%/0%

### DIFF
--- a/src/RegressionTests.jl
+++ b/src/RegressionTests.jl
@@ -610,7 +610,7 @@ function are_very_different(tags::BitVector, data; increase::Union{Bool, Nothing
     end
     any(isnothing, extremas) && return false # Maybe error?
     f, t = extremas
-    delta = (f[2] - f[1]) + (t[2] - t[1])
+    delta = min(f[2] - f[1], t[2] - t[1])
     f[2] + delta < t[1] && increase !== true ||
     t[2] + delta < f[1] && increase !== false
 end

--- a/src/RegressionTests.jl
+++ b/src/RegressionTests.jl
@@ -610,9 +610,9 @@ function are_very_different(tags::BitVector, data; increase::Union{Bool, Nothing
     end
     any(isnothing, extremas) && return false # Maybe error?
     f, t = extremas
-    perfect = f[1] == f[2] && t[1] == t[2]
-    f[2] < t[1] && (perfect || !isapprox(t[1], f[2]; rtol=.01)) && increase !== true ||
-    t[2] < f[1] && (perfect || !isapprox(f[1], t[2]; rtol=.01)) && increase !== false
+    delta = (f[2] - f[1]) + (t[2] - t[1])
+    f[2] + delta < t[1] && increase !== true ||
+    t[2] + delta < f[1] && increase !== false
 end
 
 # Callie

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Pkg
     end
 
     @testset "Correctness" begin
+        @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 100:100:300))
         @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103))
         @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103), increase=true)
         @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103), increase=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,11 +9,13 @@ using Pkg
     end
 
     @testset "Correctness" begin
-        @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), 1:6)
-        @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), 1:6, increase=true)
-        @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), 1:6, increase=false)
+        @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103))
+        @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103), increase=true)
+        @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(1:3, 101:103), increase=false)
+        @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), 1:6)
         @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), (1:6) .+ 10000)
         @test RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(fill(pi, 3), fill(nextfloat(float(pi)), 3)))
+        @test !RegressionTests.are_very_different(vcat(trues(3), falses(3)), vcat(fill(float(pi), 6)))
     end
 
     # TODO: make this work when it comes after "Example usage" as well.


### PR DESCRIPTION
Designed to prevent this
```
Increase
@elapsed for _ = 1:100
    my_prod(x)
end
@ /home/runner/work/RegressionTests.jl/RegressionTests.jl/test/TestPackage/bench/runbenchmarks.jl:15
occurrence: 2/3
primary                                            ▂   ▃                 
▁ ▁ ▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▄▁▁▄▁▂▃▁▅▁▁▇▁▆▁▁█▁█▁█▁▁▇▁▆▁▁▁▁▁ ▁ ▁ ▁ 
comparison      ▄  ▇  ▁                                                  
▁ ▁ ▂ ▁▁▇▁▁▁▅▁▁▁█▁▁█▁▁██▁▁▅▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ ▁ ▁ 
∞ 0 < └2.13812e-7                                      4.27665e-7┘ < ∞ N
```

Now upside noise on the primary decreases the odds of reporting an increase. Oh well, false positives trump sensitivity.

Followup for #8